### PR TITLE
Update the brief example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ Here's a brief but complete example of how to place and cancel an order. [This e
 
 ```
 import decimal
+import mango
 import os
 import time
-
-import mango
-from mango.oracles.market.market import MarketOracle
 
 # Load the wallet from the environment variable 'KEYPAIR'. (Other mechanisms are available.)
 wallet = mango.Wallet(os.environ.get("KEYPAIR"))

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here's a brief but complete example of how to place and cancel an order. [This e
 
 ```
 import decimal
+import os
 import time
 
 import mango

--- a/README.md
+++ b/README.md
@@ -61,15 +61,12 @@ market = mango.ensure_market_loaded(context, stub)
 
 market_operations = mango.create_market_operations(context, wallet, account, market, dry_run=False)
 
-print("Orders (initial):\n\t", market_operations.load_orderbook())
+print("Initial order book:\n\t", market_operations.load_orderbook())
+print("Your current orders:\n\t", market_operations.load_my_orders())
 
-# Check the current price in the devnet SOL-PERP Mango Markets oracle
-oracle = MarketOracle(market)
-price = oracle.fetch_price(context)
-
-# Go on - try to buy 1 SOL-PERP contract for the current best bid.
+# Go on - try to buy 1 SOL-PERP contract for $10.
 order = mango.Order.from_basic_info(side=mango.Side.BUY,
-                                    price=price.top_bid,
+                                    price=decimal.Decimal(10),
                                     quantity=decimal.Decimal(1),
                                     order_type=mango.OrderType.POST_ONLY)
 placed_order = market_operations.place_order(order)
@@ -78,7 +75,8 @@ print("\n\nPlaced order:\n\t", placed_order)
 print("\n\nSleeping for 10 seconds...")
 time.sleep(10)
 
-print("\n\nOrders (including our new order):\n", market_operations.load_orderbook())
+print("\n\nOrder book (including our new order):\n", market_operations.load_orderbook())
+print("Your current orders:\n\t", market_operations.load_my_orders())
 
 cancellation_signatures = market_operations.cancel_order(placed_order)
 print("\n\nCancellation signature:\n\t", cancellation_signatures)
@@ -86,7 +84,8 @@ print("\n\nCancellation signature:\n\t", cancellation_signatures)
 print("\n\nSleeping for 10 seconds...")
 time.sleep(10)
 
-print("\n\nOrders (without our order):\n", market_operations.load_orderbook())
+print("\n\nOrder book (without our order):\n", market_operations.load_orderbook())
+print("Your current orders:\n\t", market_operations.load_my_orders())
 
 ```
 


### PR DESCRIPTION
The existing example is not functional, due to the change from `load_orders` -> `load_orderbook` in [this commit](https://github.com/blockworks-foundation/mango-explorer/commit/56599a1037f2127fa09836599f4e6094b34f880b).

This changeset amends the example to be functional, with a small modification to place the order at a value we'd typically expect to see in the orderbook representation rather than a fixed $ value, which is hopefully a bit easier for a first time user to understand when they can see their order in the orderbook.

I have kept the `print` convention of the existing example, but please let me know if you would prefer it be changed to a Python 3.7-esque syntax with f-strings etc.

<details>
<summary>Log output from the example included below:</summary>

```
Orders (initial):
	 « OrderBook SOL-PERP [spread: 140.94000000, 82.142%]
	BUY      98,443.41000000 at         171.58000000   :: SELL       9,262.33000000 at         312.52000000
	BUY           0.01000000 at         100.00000000   :: SELL      10,000.00000000 at         313.24000000
	BUY           0.01000000 at         100.00000000   :: SELL           0.10000000 at         500.00000000
	BUY           0.01000000 at         100.00000000   :: 
	BUY           0.01000000 at         100.00000000   :: 
»


Placed order:
	 « Order BUY for 1.00000000 at 171.58000000 [ID: 0 / 1640726013288] POST_ONLY »


Sleeping for 10 seconds...


Orders (including our new order):
 « OrderBook SOL-PERP [spread: 140.94000000, 82.142%]
	BUY      98,443.41000000 at         171.58000000   :: SELL       9,262.33000000 at         312.52000000
	BUY           1.00000000 at         171.58000000   :: SELL      10,000.00000000 at         313.24000000
	BUY           0.01000000 at         100.00000000   :: SELL           0.10000000 at         500.00000000
	BUY           0.01000000 at         100.00000000   :: 
	BUY           0.01000000 at         100.00000000   :: 
»


Cancellation signature:
	 ['2E3etN9jdFC4eV5zhrCEv5P4BdzVq4auHnK4oG1SKbUhyXMMBGT4Jd1T5KXB7c7s6u8FGwz1AA3Y3yAVapWBWvEX']


Sleeping for 10 seconds...


Orders (without our order):
 « OrderBook SOL-PERP [spread: 140.94000000, 82.142%]
	BUY      98,443.41000000 at         171.58000000   :: SELL       9,262.33000000 at         312.52000000
	BUY           0.01000000 at         100.00000000   :: SELL      10,000.00000000 at         313.24000000
	BUY           0.01000000 at         100.00000000   :: SELL           0.10000000 at         500.00000000
	BUY           0.01000000 at         100.00000000   :: 
	BUY           0.01000000 at         100.00000000   :: 
»
```
</details>