### PR TITLE
Using different ports for http and ws connections

### DIFF
--- a/docs/CommonParameters.md
+++ b/docs/CommonParameters.md
@@ -57,6 +57,14 @@ For example, to switch to the public Solana endpoint you would specify:
 ---cluster-url https://api.mainnet-beta.solana.com
 ```
 
+There is an optional possibility to provide two parameters to the `--cluster-url` argument. Then the first parameter defines HTTP url of the RPC node
+and the second one defines WS url of the RPC node.
+
+For example, if you want to place order via one RPC node while loading market data via websocket connection from a different node
+```
+--cluster-url https://localhost:80 wss://localhost:443
+```
+
 There are several different RPC node providers now who provide free or premium RPC node connectivity. Use the URL they send you here.
 
 **Note** This parameter is unusual in that it can be specified multiple times. This allows you to provide multiple RPC nodes and have the program switch to the next node if a node displays problems. For example, you can specify `--cluster-url` 3 times (with 3 different RPC URLs) and if one node starts rate-limiting you, the program will automatically switch to using the next node you specified. You'll only see exceptions if all 3 nodes have problems at the same time.

--- a/mango/__init__.py
+++ b/mango/__init__.py
@@ -27,6 +27,7 @@ from .cache import PerpMarketCache as PerpMarketCache
 from .cache import PriceCache as PriceCache
 from .cache import RootBankCache as RootBankCache
 from .client import BetterClient as BetterClient
+from .client import ClusterUrlData as ClusterUrlData
 from .client import BlockhashNotFoundException as BlockhashNotFoundException
 from .client import ClientException as ClientException
 from .client import CompoundException as CompoundException

--- a/mango/context.py
+++ b/mango/context.py
@@ -24,7 +24,7 @@ from rx.scheduler.threadpoolscheduler import ThreadPoolScheduler
 from solana.publickey import PublicKey
 from solana.rpc.commitment import Commitment
 
-from .client import BetterClient
+from .client import BetterClient, ClusterUrlData
 from .constants import MangoConstants
 from .instructionreporter import InstructionReporter, CompoundInstructionReporter
 from .instrumentlookup import InstrumentLookup
@@ -37,7 +37,7 @@ from .text import indent_collection_as_str, indent_item_by
 # A `Context` object to manage Solana connection and Mango configuration.
 #
 class Context:
-    def __init__(self, name: str, cluster_name: str, cluster_urls: typing.Sequence[str], skip_preflight: bool,
+    def __init__(self, name: str, cluster_name: str, cluster_urls: typing.Sequence[ClusterUrlData], skip_preflight: bool,
                  commitment: str, encoding: str, blockhash_cache_duration: int,
                  stale_data_pauses_before_retry: typing.Sequence[float], mango_program_address: PublicKey,
                  serum_program_address: PublicKey, group_name: str, group_address: PublicKey,

--- a/mango/websocketsubscription.py
+++ b/mango/websocketsubscription.py
@@ -59,7 +59,7 @@ class WebSocketSubscription(Disposable, typing.Generic[TSubscriptionInstance], m
         raise NotImplementedError("WebSocketSubscription.build_request() is not implemented on the base type.")
 
     def open(self,) -> None:
-        websocket_url: str = self.context.client.cluster_url.replace("https", "wss", 1)
+        websocket_url: str = self.context.client.cluster_ws_url
 
         def on_open(sock: websocket.WebSocketApp) -> None:
             sock.send(self.build_request())
@@ -256,7 +256,7 @@ class SharedWebSocketSubscriptionManager(WebSocketSubscriptionManager):
         self._pong_subscription: typing.Optional[Disposable] = None
 
     def open(self) -> None:
-        websocket_url = self.context.client.cluster_url.replace("https", "wss", 1)
+        websocket_url = self.context.client.cluster_ws_url
         ws: ReconnectingWebsocket = ReconnectingWebsocket(websocket_url, self.open_handler)
         ws.item.subscribe(on_next=self.on_item)  # type: ignore[call-arg]
         ws.ping_interval = self.ping_interval

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -29,7 +29,7 @@ class MockCompatibleClient(Client):
 
 class MockClient(mango.BetterClient):
     def __init__(self) -> None:
-        rpc = mango.RPCCaller("fake", "http://localhost", [], mango.SlotHolder(), mango.InstructionReporter())
+        rpc = mango.RPCCaller("fake", "http://localhost", "ws://localhost", [], mango.SlotHolder(), mango.InstructionReporter())
         compound = mango.CompoundRPCCaller("fake", [rpc])
         super().__init__(MockCompatibleClient(), "test", "local", Commitment("processed"),
                          False, "base64", 0, compound)
@@ -46,7 +46,10 @@ def fake_seeded_public_key(seed: str) -> PublicKey:
 def fake_context() -> mango.Context:
     context = mango.Context(name="Mango Test",
                             cluster_name="test",
-                            cluster_urls=["http://localhost", "http://localhost"],
+                            cluster_urls=[
+                                mango.ClusterUrlData(rpc="http://localhost"),
+                                mango.ClusterUrlData(rpc="http://localhost")
+                            ],
                             skip_preflight=False,
                             commitment="processed",
                             encoding="base64",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ __FAKE_RPC_METHOD = RPCMethod("fake")
 
 class FakeRPCCaller(mango.RPCCaller):
     def __init__(self) -> None:
-        super().__init__("Fake", "https://localhost", [0.1, 0.2], mango.SlotHolder(), mango.InstructionReporter())
+        super().__init__("Fake", "https://localhost", "wss://localhost", [0.1, 0.2], mango.SlotHolder(), mango.InstructionReporter())
         self.called = False
 
     def make_request(self, method: RPCMethod, *params: typing.Any) -> RPCResponse:
@@ -25,7 +25,7 @@ class FakeRPCCaller(mango.RPCCaller):
 
 class RaisingRPCCaller(mango.RPCCaller):
     def __init__(self) -> None:
-        super().__init__("Fake", "https://localhost", [0.1, 0.2], mango.SlotHolder(), mango.InstructionReporter())
+        super().__init__("Fake", "https://localhost", "wss://localhost", [0.1, 0.2], mango.SlotHolder(), mango.InstructionReporter())
         self.called = False
 
     def make_request(self, method: RPCMethod, *params: typing.Any) -> RPCResponse:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -25,7 +25,8 @@ def test_new_from_cluster() -> None:
     context_has_default_values(mango.ContextBuilder.default())
     derived = mango.ContextBuilder.build(cluster_name="devnet")
     assert derived.client.cluster_name == "devnet"
-    assert derived.client.cluster_url == "https://mango.devnet.rpcpool.com"
+    assert derived.client.cluster_rpc_url == "https://mango.devnet.rpcpool.com"
+    assert derived.client.cluster_ws_url == "wss://mango.devnet.rpcpool.com"
     assert derived.mango_program_address == PublicKey("4skJ85cdxQAFVKbcGgfun8iZPL7BadVYXG3kGEGkufqA")
     assert derived.serum_program_address == PublicKey("DESVgJVGajEgKGXhb6XmqDHGz3VjdgP7rEVESBgxmroY")
     assert derived.group_name == "devnet.2"


### PR DESCRIPTION
I would like to use the PR as a manner to discuss a trouble when I want to use different ports for HTTP(S) and WS(S) connections.
Currently the `cluster_urls` can be configured as `https` and then the protocol is switched for `wss` when websocket subscription is created : https://github.com/blockworks-foundation/mango-explorer/blob/main/mango/websocketsubscription.py#L62

What I would need is having chance to define different protocol `https vs. ws` and/or different port for WS and HTTP connections.

I'm thinking about changes in code. (The currently proposed ones neither work fully nor are clean for being good to be merged.)

I was thinking to have instead of `cluster_urls: typing.Sequence[str]` a dictionary like `cluster_urls: typing.Dict[str,str]` where would be possible to say `cluster_urls = {'https': 'https://localhost:8080', 'ws': 'ws://localhost:8181'}`. But this kind of change is more difficult to place to be loaded from command line args (or maybe not and I just need to find how to do it). I took kind of side step here in way to represent the issue.

If such kind of change would be desirable then I would fix and clean the proposed code in way that will be recommended to me. 
If such kind of change is not a thing that should be part of this codebase I will delete this PR.

Thank you for any feedback.