### PR TITLE
Working with uppercase symbol from solana token list when serum lookup find_by_symbol is used

### DIFF
--- a/mango/serummarketlookup.py
+++ b/mango/serummarketlookup.py
@@ -89,14 +89,14 @@ class SerumMarketLookup(MarketLookup):
         if base_data is None:
             self._logger.warning(f"Could not find data for base token '{base_symbol}'")
             return None
-        base = Token(base_data["symbol"], base_data["name"], Decimal(
+        base = Token(base_data["symbol"].upper(), base_data["name"], Decimal(
             base_data["decimals"]), PublicKey(base_data["address"]))
 
         quote_data = SerumMarketLookup._find_data_by_symbol(quote_symbol, self.token_data)
         if quote_data is None:
             self._logger.warning(f"Could not find data for quote token '{quote_symbol}'")
             return None
-        quote = Token(quote_data["symbol"], quote_data["name"], Decimal(
+        quote = Token(quote_data["symbol"].upper(), quote_data["name"], Decimal(
             quote_data["decimals"]), PublicKey(quote_data["address"]))
 
         if "extensions" not in base_data:


### PR DESCRIPTION
I was trying to load MSOL/SOL serum market and I was not able to get there.
That one is loaded from information at `solana.tokenlist.json` by code `serummarketlookup.py` using `find_by_symbol`.

The tokenlist talks defines
```
"chainId": 101,
      "address": "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",
      "symbol": "mSOL",
```

while the loading by symbol works completely with upper case
https://github.com/blockworks-foundation/mango-explorer/blob/main/mango/serummarketlookup.py#L83

That means that defining symbol `MSOL/SOL` does not work as the tokenlist knows only about `mSOL` and loading `mSOL/SOL` does not work as it's always converted to upper case.

I'm proposing to upper case the symbols from token list in code as well.
WDYT @OpinionatedGeek 