### PR TITLE
Pyth Oracle changed the account info at mainnet by adding prefix 'Crypto.' to assets

### DIFF
--- a/mango/oracles/pythnetwork/pythnetwork.py
+++ b/mango/oracles/pythnetwork/pythnetwork.py
@@ -112,7 +112,7 @@ class PythOracle(Oracle):
 class PythOracleProvider(OracleProvider):
     def __init__(self, context: Context) -> None:
         self.address: PublicKey = PYTH_MAINNET_MAPPING_ROOT if context.client.cluster_name == "mainnet" else PYTH_DEVNET_MAPPING_ROOT
-        self.__symbol_prefix = "" if context.client.cluster_name == "mainnet" else "Crypto."
+        self.__symbol_prefix = "Crypto."
 
         super().__init__(f"Pyth Oracle Factory [{self.address}]")
         self.context: Context = context


### PR DESCRIPTION
Based on the fact that Pyth Oracle stopped working today and when looking through the history
https://github.com/blockworks-foundation/mango-explorer/commit/8ad90339482e732e489e005fc2151c0984fab1c9
then I found the Pyth network changes that were deployed at mainnet today
https://pythnetwork.medium.com/pyth-symbology-update-february-3rd-2022-554c0bc1463b

Proposing this quick fix. Maybe there could be missing something more.