### PR TITLE
BetterClient to use the first rpc url from list in the same way as CompoundRPCCaller

### DIFF
--- a/mango/client.py
+++ b/mango/client.py
@@ -900,7 +900,7 @@ class BetterClient:
         if blockhash_cache_duration > 0:
             blockhash_cache = BlockhashCache(blockhash_cache_duration)
         client: Client = Client(
-            endpoint=cluster_url.rpc,
+            endpoint=cluster_urls[0].rpc,
             commitment=commitment,
             blockhash_cache=blockhash_cache,
         )


### PR DESCRIPTION
If I'm not mistaken (?) the `BetterClient` at initialization starts using the last RPC url from the list while `CompoundRPCCaller` uses the first one.
This should be adjusted to work with the first RPC url from start.