### PR TITLE
Make bin/ balance-wallet to work

### DIFF
--- a/bin/balance-wallet
+++ b/bin/balance-wallet
@@ -59,8 +59,6 @@ args: argparse.Namespace = mango.parse_args(parser)
 with mango.ContextBuilder.from_command_line_parameters(args) as context:
     wallet: mango.Wallet = mango.Wallet.from_command_line_parameters_or_raise(args)
     action_threshold: Decimal = args.action_threshold
-    adjustment_factor: Decimal = args.adjustment_factor
-    action_threshold = args.action_threshold
     max_slippage = args.max_slippage
     group = mango.Group.load(context, context.group_address)
     account = mango.Account.load_for_owner_by_address(


### PR DESCRIPTION
The `balance-wallet` command does not work as requires a parameter which is not needed in fact.