### PR TITLE
Use SOL-PERP instead of BTC-PERP in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Many more examples are provided in a separate [Github repo](https://github.com/b
 ### 🏃 Show OrderBook
 > [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/blockworks-foundation/mango-explorer-examples/HEAD?labpath=ShowOrderBook.ipynb) [Full runnable code in `mango-explorer-examples` repo](https://github.com/blockworks-foundation/mango-explorer-examples/blob/main/ShowOrderBook.ipynb)
 
-This code will connect to the _devnet_ cluster, fetch the orderbook for BTC-PERP, and print out a summary of it:
+This code will connect to the _devnet_ cluster, fetch the orderbook for SOL-PERP, and print out a summary of it:
 ```
 import mango
 
 with mango.ContextBuilder.build(cluster_name="devnet") as context:
-    market = mango.market(context, "BTC-PERP")
+    market = mango.market(context, "SOL-PERP")
     print(market.fetch_orderbook(context))
 ```
 
@@ -70,7 +70,7 @@ import mango
 import time
 
 with mango.ContextBuilder.build(cluster_name="devnet") as context:
-    market = mango.market(context, "BTC-PERP")
+    market = mango.market(context, "SOL-PERP")
     subscription = market.on_orderbook_change(context, lambda ob: print("\n", datetime.datetime.now(), "\n", ob))
 
     time.sleep(60)
@@ -89,7 +89,7 @@ This code will connect to the _devnet_ cluster and fetch all recent events. It w
 import mango
 
 with mango.ContextBuilder.build(cluster_name="devnet") as context:
-    market = mango.market(context, "BTC-PERP")
+    market = mango.market(context, "SOL-PERP")
     event_queue = mango.PerpEventQueue.load(context, market.event_queue_address, market.lot_size_converter)
     print(event_queue.fills)
 ```
@@ -105,7 +105,7 @@ import mango
 import time
 
 with mango.ContextBuilder.build(cluster_name="devnet") as context:
-    market = mango.market(context, "BTC-PERP")
+    market = mango.market(context, "SOL-PERP")
     subscription = market.on_fill(context, lambda ob: print("\n", datetime.datetime.now(), "\n", ob))
 
     time.sleep(60)

--- a/docs/MarketmakingQuickstart.md
+++ b/docs/MarketmakingQuickstart.md
@@ -97,6 +97,7 @@ Next, we’ll set up an `alias` to make running the container easier. There are 
     gcr.io/mango-markets/mango-explorer:latest"
 ```
 It’s probably a good idea to put this alias in your `.profile` or `.bashrc` (or use whatever mechanism your shell uses for such things).
+You may also wish to adjust the `-v` parameter above if you checked out the code in an alternative location.
 
 
 # 4. 👛 Create The Wallet
@@ -154,7 +155,7 @@ SOL tokens are needed for running operations on the Solana blockchain, similar t
 
 To do this, run the command:
 ```
-# mango-explorer airdrop --symbol SOL --quantity 1 --url devnet
+# mango-explorer airdrop --symbol SOL --quantity 1 --cluster-name devnet
 ```
 This will transfer 1 SOL to **6MEVCr816wapduGknarkNRwMFWvFQSNv5h7iQEGGx8uB**, the address shown above when creating the wallet.
 


### PR DESCRIPTION
Since there is no BTC-PERT on devnet any more. Here's the PR to update the main README file and the market maker quick-start.

There are two tiny other changes to the doc, one to make it slightly more friendly, and the other is to correct something broken because this market maker demo does not support the `--url devnet` parameter.

One other thing though, the market maker quick-start still doesn't run, reporting `Could not find base instrument with symbol 'FTT'`. This has to do with other symbol changes in the system I think. I'm happy to take a crack at it too, but let me know if you think it has to be in this PR, or you can merge this first. 